### PR TITLE
Add OpenCode plugin for Forge skills and MCP servers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,15 @@ jobs:
       - name: Run tests
         working-directory: skills/forge-app-builder
         run: python -m unittest discover -s tests -v
+
+  opencode-plugin:
+    name: OpenCode plugin
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Test OpenCode plugin
+        run: bun test ./.opencode-plugin/forge-skills.test.js

--- a/.opencode-plugin/forge-skills.js
+++ b/.opencode-plugin/forge-skills.js
@@ -1,0 +1,64 @@
+/**
+ * Forge Skills — OpenCode plugin
+ *
+ * Registers the Atlassian Forge skill bundle and its MCP servers for OpenCode,
+ * mirroring the per-host manifests in this repo (.claude-plugin/, .cursor-plugin/,
+ * .codex-plugin/, gemini-extension.json).
+ *
+ * OpenCode loads this plugin via the repo's `opencode.json` (`plugin` array), so
+ * opening this repo in OpenCode makes all six Forge skills and both MCP servers
+ * available — no manual setup required.
+ *
+ * To use the skills from any other project, add this file to your global config
+ * (~/.config/opencode/opencode.json):
+ *
+ *   {
+ *     "$schema": "https://opencode.ai/config.json",
+ *     "plugin": ["file:///ABSOLUTE/PATH/TO/forge-skills/.opencode-plugin/forge-skills.js"]
+ *   }
+ *
+ * The skills path is resolved from this file's own location, so it keeps pointing
+ * at this repo's `skills/` directory regardless of the working directory.
+ *
+ * @see https://opencode.ai/docs/plugins/
+ * @see https://opencode.ai/docs/skills/
+ * @see https://opencode.ai/docs/mcp-servers/
+ */
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// This file lives at <repo>/.opencode-plugin/forge-skills.js;
+// the skill bundle lives at <repo>/skills (one level up).
+const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url));
+const SKILLS_DIR = resolve(PLUGIN_DIR, "..", "skills");
+
+// Remote MCP servers shared with the other hosts (see .mcp.json).
+const MCP_SERVERS = {
+  forge: {
+    type: "remote",
+    url: "https://mcp.atlassian.com/v1/forge/mcp",
+    enabled: true,
+  },
+  "ads-mcp": {
+    type: "remote",
+    url: "https://mcp.atlassian.com/v1/ads/public/mcp",
+    enabled: true,
+  },
+};
+
+export const ForgeSkillsPlugin = async () => ({
+  config: async (config) => {
+    // Register the Forge + ADS MCP servers (idempotent: never overwrite user config).
+    config.mcp ??= {};
+    for (const [name, server] of Object.entries(MCP_SERVERS)) {
+      if (!config.mcp[name]) config.mcp[name] = server;
+    }
+
+    // Make the bundled Forge skills (skills/<name>/SKILL.md) discoverable.
+    config.skills ??= {};
+    if (!Array.isArray(config.skills.paths)) config.skills.paths = [];
+    if (!config.skills.paths.includes(SKILLS_DIR)) {
+      config.skills.paths.push(SKILLS_DIR);
+    }
+  },
+});

--- a/.opencode-plugin/forge-skills.test.js
+++ b/.opencode-plugin/forge-skills.test.js
@@ -1,0 +1,40 @@
+import { test, expect } from "bun:test";
+import { ForgeSkillsPlugin } from "./forge-skills.js";
+
+test("registers the Forge and ADS MCP servers and the skills path", async () => {
+  const hooks = await ForgeSkillsPlugin();
+  const config = {};
+  await hooks.config(config);
+
+  expect(config.mcp.forge).toEqual({
+    type: "remote",
+    url: "https://mcp.atlassian.com/v1/forge/mcp",
+    enabled: true,
+  });
+  expect(config.mcp["ads-mcp"].url).toBe("https://mcp.atlassian.com/v1/ads/public/mcp");
+  expect(Array.isArray(config.skills.paths)).toBe(true);
+  expect(config.skills.paths.some((p) => p.endsWith("/skills"))).toBe(true);
+});
+
+test("is idempotent across repeated config hooks", async () => {
+  const hooks = await ForgeSkillsPlugin();
+  const config = {};
+  await hooks.config(config);
+  await hooks.config(config);
+
+  expect(Object.keys(config.mcp)).toHaveLength(2);
+  expect(config.skills.paths.filter((p) => p.endsWith("/skills"))).toHaveLength(1);
+});
+
+test("never overwrites user-provided MCP or skills config", async () => {
+  const hooks = await ForgeSkillsPlugin();
+  const config = {
+    mcp: { forge: { type: "remote", url: "https://example.test/custom", enabled: false } },
+    skills: { paths: ["/custom/skills-root"] },
+  };
+  await hooks.config(config);
+
+  expect(config.mcp.forge.url).toBe("https://example.test/custom");
+  expect(config.mcp["ads-mcp"]).toBeDefined();
+  expect(config.skills.paths).toContain("/custom/skills-root");
+});

--- a/README.md
+++ b/README.md
@@ -100,6 +100,43 @@ codex plugin marketplace upgrade atlassian-forge-skills
 codex plugin add forge-skills@atlassian-forge-skills
 ```
 
+### OpenCode
+
+[OpenCode](https://opencode.ai) is configured by the repo's [`opencode.json`](opencode.json), which loads the plugin at [`.opencode-plugin/forge-skills.js`](.opencode-plugin/forge-skills.js). Opening this repo in OpenCode makes all six skills plus the Forge and ADS MCP servers available — no manual setup.
+
+Verify they loaded:
+
+```bash
+opencode debug skill   # lists the six forge-* skills
+opencode mcp list      # shows the forge and ads-mcp servers
+```
+
+The Forge MCP server uses Atlassian OAuth — sign in once with `opencode mcp auth forge` (authenticate any other server the same way if prompted).
+
+To use the Forge skills from **any** project (not just this repo), reference the plugin from your global config at `~/.config/opencode/opencode.json` with an absolute path to your checkout:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["file:///ABSOLUTE/PATH/TO/forge-skills/.opencode-plugin/forge-skills.js"]
+}
+```
+
+The plugin resolves the skills directory from its own location, so it keeps pointing at this repo's `skills/` no matter which project you run OpenCode in.
+
+**Prefer plain config?** Instead of the plugin, replace the repo's `opencode.json` with a declarative version that wires the MCP servers and skills directly. The relative `./skills` resolves against the repo root — for a **global** `~/.config/opencode/opencode.json`, use an absolute path to your checkout's `skills/` instead:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "forge": { "type": "remote", "url": "https://mcp.atlassian.com/v1/forge/mcp", "enabled": true },
+    "ads-mcp": { "type": "remote", "url": "https://mcp.atlassian.com/v1/ads/public/mcp", "enabled": true }
+  },
+  "skills": { "paths": ["./skills"] }
+}
+```
+
 ### Rovo Dev
 
 Rovo Dev doesn't currently support plugin installations but you can install the skills and MCP servers separately.
@@ -183,6 +220,7 @@ Once the plugin is installed, try prompts like these:
 | **Forge Security Review** | `skills/forge-security-review/`                                                                | White-box security audits with rule assets (`SKILL.md`, README, assets/)       |
 | **MCP config**            | `.mcp.json`                                                                                    | Forge MCP Server and ADS MCP Server configuration                              |
 | **Plugin manifests**      | `.cursor-plugin/`, `.claude-plugin/`, `.codex-plugin/`, `plugin.json`, `gemini-extension.json` | Per-host plugin metadata and MCP wiring                                        |
+| **OpenCode plugin**       | `.opencode-plugin/`, `opencode.json`                                                           | OpenCode plugin (loaded via `opencode.json`): registers the skills + Forge/ADS MCP |
 
 ## Authentication
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["./.opencode-plugin/forge-skills.js"]
+}


### PR DESCRIPTION
## What

Adds [OpenCode](https://opencode.ai) as a supported host. The same six Forge skills and the Forge + ADS MCP servers now work in OpenCode. Resolves #14.

## How

OpenCode has no declarative skill/MCP manifest like the other hosts; it loads `opencode.json` config and/or JS/TS plugins. This PR adds:

- `.opencode-plugin/forge-skills.js` — a small, dependency-free plugin whose `config` hook registers the `forge` and `ads-mcp` remote MCP servers (same endpoints as `.mcp.json`) and adds `skills/` to `skills.paths`, resolved from the plugin's own location via `import.meta`.
- `opencode.json` — loads the plugin via its `plugin` array.

The folder is named `.opencode-plugin/` to match the existing per-host convention (`.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`); it's loaded via `opencode.json` because OpenCode only auto-discovers its default `.opencode/plugins/` directory. Opening the repo in OpenCode then exposes all six skills + both MCP servers. The hook is idempotent and never overwrites user config.

(If you'd prefer OpenCode's idiomatic `.opencode/plugins/` auto-load, or a fully declarative `opencode.json`, I'm happy to switch — see #14.)

## Testing

- `.opencode-plugin/forge-skills.test.js` (Bun): registration, idempotency, and non-clobber behavior (3 tests). A new `opencode-plugin` CI job runs `bun test`.
- Manual: OpenCode v1.17.7 — `opencode debug skill` lists the six `forge-*` skills; `opencode mcp list` shows `forge` + `ads-mcp`.

## Checklist

- [x] CLA signed (individual)
- [x] Tests added for the new feature
- [x] Follows existing style
- [x] No unrelated changes
