### PR TITLE
Add Agent Plugins v1 compatibility

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "forge-skills",
   "description": "Forge app builder skill bundle with Forge MCP integration for Atlassian Forge workflows.",
   "version": "0.1.0",
@@ -9,5 +8,7 @@
   "homepage": "https://github.com/atlassian/forge-skills",
   "repository": "https://github.com/atlassian/forge-skills.git",
   "license": "Apache-2.0",
-  "keywords": ["forge", "atlassian", "jira", "confluence", "mcp", "skills"]
+  "keywords": ["forge", "atlassian", "jira", "confluence", "mcp", "skills"],
+  "skills": ["./skills/"],
+  "mcpServers": ".mcp.json"
 }

--- a/README.md
+++ b/README.md
@@ -93,12 +93,24 @@ codex plugin add forge-skills@atlassian-forge-skills
 
 Start a new Codex thread after installing so the Forge skills and MCP servers are loaded.
 
-To refresh the marketplace after updates:
+To refresh the Codex marketplace after updates:
 
 ```bash
 codex plugin marketplace upgrade atlassian-forge-skills
 codex plugin add forge-skills@atlassian-forge-skills
 ```
+
+### Kiro and Agent Plugins clients
+
+This repository follows the [Agent Plugins v1.0.0 specification](https://agent-plugins.org/). In Kiro, open the Powers panel, choose **Add Custom Power**, and import this repository from GitHub or from a local checkout.
+
+Portable clients discover:
+
+- `plugin.json` for plugin identity and metadata
+- `skills/*/SKILL.md` for Agent Skills
+- `mcp.json` for Forge and Atlassian Design System MCP servers
+
+The separate `.mcp.json` and client-specific manifest directories remain in place for clients that use their own plugin formats.
 
 ### Rovo Dev
 
@@ -177,12 +189,12 @@ Once the plugin is installed, try prompts like these:
 | ------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
 | **Forge App Builder**     | `skills/forge-app-builder/`                                                                    | Create, deploy, install; helper scripts and tests                              |
 | **Forge App Review**      | `skills/forge-app-review/`                                                                     | Pre-deploy review and audits (`SKILL.md`, README)                              |
-| **Forge Cost Optimizer**  | `skills/forge-cost-optimizer/`                                                                | Reduce Forge platform consumption across invocations, storage, logs, and memory |
+| **Forge Cost Optimizer**  | `skills/forge-cost-optimizer/`                                                                 | Reduce Forge platform consumption across invocations, storage, logs, and memory |
 | **Forge Connector**       | `skills/forge-connector/`                                                                      | Build graph:connector apps; ingest data into Teamwork Graph (SKILL.md, README) |
 | **Forge Debugger**        | `skills/forge-debugger/`                                                                       | Troubleshooting and diagnostics (`SKILL.md`, README)                           |
 | **Forge Security Review** | `skills/forge-security-review/`                                                                | White-box security audits with rule assets (`SKILL.md`, README, assets/)       |
-| **MCP config**            | `.mcp.json`                                                                                    | Forge MCP Server and ADS MCP Server configuration                              |
-| **Plugin manifests**      | `.cursor-plugin/`, `.claude-plugin/`, `.codex-plugin/`, `plugin.json`, `gemini-extension.json` | Per-host plugin metadata and MCP wiring                                        |
+| **MCP config**            | `mcp.json`, `.mcp.json`                                                                        | Forge MCP Server and ADS MCP Server configuration                    |
+| **Plugin manifests**      | `plugin.json`, `.plugin/`, `.cursor-plugin/`, `.claude-plugin/`, `.codex-plugin/`, `gemini-extension.json` | Per-host plugin metadata and MCP wiring                 |
 
 ## Authentication
 

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "forge": {
+      "type": "streamable-http",
+      "url": "https://mcp.atlassian.com/v1/forge/mcp"
+    },
+    "ads-mcp": {
+      "type": "streamable-http",
+      "url": "https://mcp.atlassian.com/v1/ads/public/mcp"
+    }
+  }
+}

--- a/skills/forge-connector/SKILL.md
+++ b/skills/forge-connector/SKILL.md
@@ -10,15 +10,10 @@ description: >
   use the @forge/teamwork-graph SDK, or implement onConnectionChange / validateConnection
   functions.
 license: Apache-2.0
-labels:
-  - forge
-  - rovo
-  - jira
-  - atlassian
-  - teamwork-graph
-  - connector
-maintainer: mbanjan94
-namespace: cloud
+metadata:
+  labels: "forge,rovo,jira,atlassian,teamwork-graph,connector"
+  maintainer: mbanjan94
+  namespace: cloud
 ---
 
 # Forge Connector
@@ -750,4 +745,3 @@ The scaffold script is in this skill's directory. The deploy script is in the **
 - Use the **official service name** as the connector name (e.g. `Google Drive`, not `Drive Connector by Acme`)
 - Use the **official service logo** for icons — do not modify or combine with your own branding
 - These guidelines apply only to the `graph:connector` module; your Forge app itself may use your own branding
-

--- a/skills/forge-security-review/SKILL.md
+++ b/skills/forge-security-review/SKILL.md
@@ -6,14 +6,10 @@ description: >
   review, security audit, vuln assessment, pentest-style code review, authz review, tenant
   isolation analysis, web trigger hardening, or static analysis execution for a Forge app.
 license: Apache-2.0
-labels:
-  - forge
-  - security
-  - review
-  - audit
-  - atlassian
-maintainer: atlassian-developer
-namespace: cloud
+metadata:
+  labels: "forge,security,review,audit,atlassian"
+  maintainer: atlassian-developer
+  namespace: cloud
 ---
 
 # Forge Security Review


### PR DESCRIPTION
Adopt the portable Agent Plugins manifest and MCP layout while preserving client-specific packaging for GitHub Copilot, Codex, Claude, Cursor, Gemini, and Rovo Dev. Normalize skill metadata to the Agent Skills frontmatter format and document Kiro installation.