### PR TITLE
Update README for Claude installation - add required marketplace first

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Before you install, make sure you have:
 ### Claude Code
 
 ```
+/plugin marketplace add atlassian/forge-skills
 /plugin install forge-skills@atlassian-forge-skills
 ```
 


### PR DESCRIPTION
Per the tin, need the marketplace added otherwise `@atlassian-forge-skills` is unknown.